### PR TITLE
Feature/add pending trader sign up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,11 @@
 class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
-    admin_dashboard_path if resource.instance_of?(Admin)
+    # admin_dashboard_path if resource.instance_of?(Admin)
+    if resource.instance_of?(Admin)
+      admin_dashboard_path
+    elsif resource.instance_of?(Trader)
+      trader_portfolio_path
+    end
   end
 
   protect_from_forgery with: :exception

--- a/app/controllers/traders_controller.rb
+++ b/app/controllers/traders_controller.rb
@@ -1,5 +1,4 @@
 class TradersController < ApplicationController
-  before_action :authenticate_trader!
-
   def index; end
+  def show; end
 end

--- a/app/models/trader.rb
+++ b/app/models/trader.rb
@@ -3,4 +3,12 @@ class Trader < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  def active_for_authentication?
+    super && is_approved?
+  end
+
+  def inactive_message
+    is_approved? ? super : :not_approved
+  end
 end

--- a/app/views/traders/registrations/new.html.erb
+++ b/app/views/traders/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Sign up</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+<%= form_for(resource, as: resource_name, url: traders_sign_up_path) do |f| %>
   <%= render "traders/shared/error_messages", resource: resource %>
 
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -37,6 +37,10 @@ en:
       updated: "Your password has been changed successfully. You are now signed in."
       updated_not_active: "Your password has been changed successfully."
     registrations:
+      user:
+      signed_up_but_not_approved: 'You have signed up successfully but your account has not been approved by your administrator yet'
+      failure:
+      not_approved: 'Your account has not been approved by your administrator yet.'
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@ Rails.application.routes.draw do
   devise_for :traders
   devise_for :admins, :skip => [:registrations]
 
+  devise_scope :trader do
+    post 'traders/sign_up', to: 'devise/registrations#create'
+  end
+
   authenticated :admin do
     get '/admin/dashboard' => "admins#index"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+
+
 Rails.application.routes.draw do
   devise_for :traders
   devise_for :admins, :skip => [:registrations]
@@ -10,9 +12,10 @@ Rails.application.routes.draw do
     get '/admin/dashboard' => "admins#index"
   end
   
-    get '/trader/dashboard' => "traders#index"
   
-  root to: 'traders#index'
+  authenticated :trader do
+      get '/traders/dashboard', to: "traders#index", as: "trader_portfolio"
+  end
   
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
## Summary
  -All new registered traders will not be able to login unless of admin approval.

## Screenshots
![sample](https://user-images.githubusercontent.com/88585596/155521578-1c73cf2d-433e-440e-8645-6363b5b6894c.JPG)

## References
https://github.com/heartcombo/devise/wiki/How-To:-Require-admin-to-activate-account-before-sign_in
