### PR TITLE
Fixing confirmation password of trader registration

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:username, :fullname, :email, :password) }
+    devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:username, :fullname, :email, :password, :password_confirmation) }
 
     devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:username, :fullname, :email, :password, :current_password) }
   end

--- a/app/models/trader.rb
+++ b/app/models/trader.rb
@@ -2,7 +2,7 @@ class Trader < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :lockable, :trackable
+         :recoverable, :rememberable, :validatable
   validates :fullname, presence: true
   validates :username, presence: true
   after_create :send_email

--- a/app/models/trader.rb
+++ b/app/models/trader.rb
@@ -2,7 +2,7 @@ class Trader < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :lockable, :trackable
   validates :fullname, presence: true
   validates :username, presence: true
   after_create :send_email

--- a/spec/requests/traders_spec.rb
+++ b/spec/requests/traders_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Traders', type: :request do
   let(:trader) { create(:trader) }
+  let(:trader_pending) { create(:trader_pending) }
 
   describe 'User sign in and log out' do
     it 'returns the index page' do
@@ -12,7 +13,7 @@ RSpec.describe 'Traders', type: :request do
     it 'signs trader in' do
       sign_in trader
       get trader_portfolio_path
-      expect(response).to be_successful
+      expect(response).to have_http_status(:ok)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Should be confirmed password when trader register their account.

## Screenshot
![Capture](https://user-images.githubusercontent.com/88585596/156360212-eccbe558-f140-4ac1-a11a-71e0e381ca10.JPG)

## References
https://stackoverflow.com/questions/6543863/devise-not-validating-password-password-confirmation
